### PR TITLE
Adds 'mode' option to fetch request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,29 @@ transport.send(`
 });
 ```
 
-## Send Custom Headers
+## Send Custom Options
+
+### Headers
 
 It's possible to send custom headers like this:
 
 ```js
-const headers = {
+const options = {};
+options.headers = {
     'my-headers': 'some-value'
 };
-const transport = new HttpTransport('/graphql', {headers});
+const transport = new HttpTransport('/graphql', options);
+```
+
+### Mode
+
+Allows [any mode](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode) compatible with Isomorphic-fetch, e.g.: 'same-origin', 'cors', 'no-cors', 'navigate'.
+Default is 'cors'.
+
+```js
+const options = {};
+options.mode = 'no-cors';
+const transport = new HttpTransport('/graphql', options);
 ```
 
 ## Authentication

--- a/lib/__tests__/index.js
+++ b/lib/__tests__/index.js
@@ -43,14 +43,17 @@ describe('LokkaHTTPTransport', () => {
         },
         body: JSON.stringify({aa: 10}),
         credentials: 'include',
+        mode: 'cors',
       });
     });
 
     it('should add custom headers', () => {
-      const headers = {
-        bb: 'hello'
+      const customOptions = {
+        headers: {
+          bb: 'hello'
+        },
       };
-      const transport = new LokkaHTTPTransport('/', {headers});
+      const transport = new LokkaHTTPTransport('/', customOptions);
       const options = transport._buildOptions({aa: 10});
 
       expect(options).to.deep.equal({
@@ -61,7 +64,33 @@ describe('LokkaHTTPTransport', () => {
           bb: 'hello'
         },
         body: JSON.stringify({aa: 10}),
-        credentials: 'include'
+        credentials: 'include',
+        mode: 'cors',
+      });
+    });
+
+    it('should add custom mode', () => {
+      const customOptions = {
+        mode: 'no-cors',
+      };
+      const transport = new LokkaHTTPTransport('/', customOptions);
+      const options = transport._buildOptions({mode: 'same-origin'});
+
+      expect(options).to.deep.equal({
+        method: 'post',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({mode: 'same-origin'}),
+        credentials: 'include',
+        mode: 'no-cors',
+      });
+    });
+
+    describe('with unknown mode option', () => {
+      it('should throw error', () => {
+        expect(() => new LokkaHTTPTransport('/graphql', {mode: 'my-mode'})).to.throw('unknown mode: my-mode');
       });
     });
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,11 +16,15 @@ export class Transport extends LokkaTransport {
     if (!endpoint) {
       throw new Error('endpoint is required!');
     }
+    if (options.mode && !['same-origin', 'cors', 'no-cors', 'navigate'].includes(options.mode)) {
+      throw new Error(`unknown mode: ${options.mode}`);
+    }
 
     super();
     this._httpOptions = {
       auth: options.auth,
-      headers: options.headers || {}
+      headers: options.headers || {},
+      mode: options.mode,
     };
     this.endpoint = endpoint;
   }
@@ -35,6 +39,7 @@ export class Transport extends LokkaTransport {
       body: JSON.stringify(payload),
       // To pass cookies to the server. (supports CORS as well)
       credentials: 'include',
+      mode: this._httpOptions.mode || 'cors',
     };
 
     Object.assign(options.headers, this._httpOptions.headers);


### PR DESCRIPTION
Enables transport to use the 'mode' option in transport#send.
Ideally it would be great to allow all options supported by isomorphic-fetch.

Please advice if indeed the default mode should be 'cors' given it is currently offered as a feature for authentication/cookies.
