### PR TITLE
Publish `lib` to the npm package.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,5 +5,4 @@
 .DS_Store
 .idea
 npm-debug.log
-lib
 .babelrc


### PR DESCRIPTION
Allows consumers of this library to work in ES6 and determine how to include this module (using browserify, webpack, rollup, whatever).
