### PR TITLE
Add the data object received to the Error object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,7 @@ export class Transport extends LokkaTransport {
         const message = errors[0].message;
         const error = new Error(`GraphQL Error: ${message}`);
         error.rawError = errors;
+        error.rawData = data;
 
         throw error;
       }


### PR DESCRIPTION
Sometimes you want to use the partial data you received from the graphql server in the event of errors. With this PR you can catch the error and continue with the data you got.
