### PR TITLE
optional CORS credentials support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,8 @@ export class Transport extends LokkaTransport {
     super();
     this._httpOptions = {
       auth: options.auth,
-      headers: options.headers || {}
+      headers: options.headers || {},
+      credentials: options.credentials,
     };
     this.endpoint = endpoint;
   }
@@ -42,6 +43,9 @@ export class Transport extends LokkaTransport {
       // To pass cookies to the server. (supports CORS as well)
       credentials: 'include',
     };
+
+    // use delete property for backward compatibility
+    if(this._httpOptions.credentials === false) delete options.credentials;
 
     Object.assign(options.headers, this._httpOptions.headers);
     return options;


### PR DESCRIPTION
Support for optional credentials flag to fix:

> Response to preflight request doesn't pass access control check: A wildcard '*' cannot be used in the 'Access-Control-Allow-Origin' header when the credentials flag is true.
