### PR TITLE
fix the way fetch dependencies are loaded

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,17 +4,20 @@ import LokkaTransport from 'lokka/transport';
 // Technically, this should be handle by 'isomorphic-fetch'.
 // But it's not happening. So this is the fix
 
+const isNode = new Function("try {return this===global;}catch(e){return false;}");
+
 let fetchUrl;
 if (typeof fetch === 'function') {
   // has a native fetch implementation
   fetchUrl = fetch;
-} else if (typeof __dirname !== 'undefined') {
+} else if (isNode()) {
   // for Node.js
   fetchUrl = require('node-fetch');
   fetchUrl.Promise = Promise;
 } else {
   // for the browser
-  fetchUrl = require('whatwg-fetch');
+  require('whatwg-fetch');
+  fetchUrl = fetch;
 }
 
 export class Transport extends LokkaTransport {


### PR DESCRIPTION
According to the issue https://github.com/kadirahq/lokka-transport-http/issues/13 fetch loading is not possible on Safari.

The problem is that `typeof __dirname !== 'undefined'` condition is compiled to `true` with webpack bundle loader. A good check could be `typeof module !== 'undefined' && module.exports` which also underscore.js is using. This is not possible though because transpiled code in `dist/index.js` defines the following code, defining `module.exports`:

```
Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.Transport = undefined;
```

So the solution on checking the current environment can be this check `var isNode=new Function("try {return this===global;}catch(e){return false;}");` better explained here http://stackoverflow.com/questions/17575790/environment-detection-node-js-or-browser.

Another issue solved here is that the `require('whatwg-fetch')` doesn't export the fetch function, but it defines it on the global scope, so we have to assign `fetchUrl = fetch;` just like the native browser function.

Finally, tests pass, so let me know if you are ok with this PR. :)

_Note: Chrome and Firefox have native browser implementation for fetch._
