### PR TITLE
Support custom error handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ This package does not handle authentication information for you. But it'll let y
 
 * If you already have an authorized cookie, it'll be sent with the HTTP request. (supports CORS)
 * You can also set a custom `Authorization` [header]((https://www.npmjs.com/package/basic-auth-header) to implement [basic-auth](https://www.npmjs.com/package/basic-auth) support.
+
+## Error Handling
+
+By default it will create and throw a new `Error` object using the first GraphQL error. Error handling can be customized with the `handleErrors` option. Check the deafult error handler in `lib/index.js` for an example.

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,15 @@ if (typeof fetch === 'function') {
   fetchUrl = fetch;
 }
 
+// the default error handler
+function handleErrors(errors) {
+  const message = errors[0].message;
+  const error = new Error(`GraphQL Error: ${message}`);
+  error.rawError = errors;
+  error.rawData = data;
+  throw error;
+}
+
 export class Transport extends LokkaTransport {
   constructor(endpoint, options = {}) {
     if (!endpoint) {
@@ -33,6 +42,7 @@ export class Transport extends LokkaTransport {
       credentials: options.credentials,
     };
     this.endpoint = endpoint;
+    this.handleErrors = options.handleErrors || handleErrors;
   }
 
   _buildOptions(payload) {
@@ -68,12 +78,8 @@ export class Transport extends LokkaTransport {
       return response.json();
     }).then(({data, errors}) => {
       if (errors) {
-        const message = errors[0].message;
-        const error = new Error(`GraphQL Error: ${message}`);
-        error.rawError = errors;
-        error.rawData = data;
-
-        throw error;
+        this.handleErrors(errors);
+        return null;
       }
 
       return data;


### PR DESCRIPTION
This feature can be used for:
- formatting error message before throwing it
- tracking graphql errors (api error metrics)
