### PR TITLE
adding csrf capability

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,8 +66,8 @@ export class Transport extends LokkaTransport {
     return options;
   }
 
-  send(query, variables, operationName) {
-    const payload = {query, variables, operationName};
+  send(query, variables = {}, operationName) {
+    const payload = {query, _csrf: variables.csrf, variables, operationName};
     const options = this._buildOptions(payload);
 
     return fetchUrl(this.endpoint, options).then(response => {

--- a/package.json
+++ b/package.json
@@ -1,52 +1,53 @@
 {
-  "name": "lokka-transport-http",
-  "version": "1.6.1",
-  "description": "Isomorphic HTTP Transport for Lokka",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/kadirahq/lokka-transport-http.git"
-  },
-  "license": "MIT",
-  "options": {
-    "mocha": "--require scripts/mocha_runner lib/**/__tests__/**/*.js"
-  },
-  "keywords": [
-    "lokka",
-    "transport",
-    "http"
-  ],
-  "scripts": {
-    "prepublish": ". ./scripts/prepublish.sh",
-    "lint": "eslint ./lib",
-    "lintfix": "eslint ./lib --fix",
-    "testonly": "mocha $npm_package_options_mocha",
-    "test": "npm run lint && npm run testonly"
-  },
-  "devDependencies": {
-    "mocha": "2.x.x",
-    "chai": "3.x.x",
-    "eslint": "1.7.x",
-    "babel-eslint": "4.x.x",
-    "eslint-plugin-babel": "2.x.x",
-    "babel-cli": "6.x.x",
-    "babel-core": "6.x.x",
-    "babel-polyfill": "6.x.x",
-    "babel-preset-es2015": "6.x.x",
-    "babel-preset-stage-2": "6.x.x",
-    "babel-plugin-transform-runtime": "6.x.x",
-    "portscanner": "1.x.x",
-    "express": "4.x.x",
-    "express-graphql": "0.4.x",
-    "graphql": "0.4.x",
-    "bluebird": "2.x.x",
-    "lokka": "1.x.x"
-  },
-  "dependencies": {
-    "babel-runtime": "6.x.x",
-    "node-fetch": "^1.5.2",
-    "whatwg-fetch": "^1.0.0"
-  },
-  "peerDependencies": {
-    "lokka": "1.x.x"
-  }
+    "name": "lokka-transport-http-csrf",
+    "version": "1.6.1",
+    "description": "Isomorphic HTTP Transport for Lokka",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/kadirahq/lokka-transport-http.git"
+    },
+    "license": "MIT",
+    "options": {
+        "mocha": "--require scripts/mocha_runner lib/**/__tests__/**/*.js"
+    },
+    "keywords": [
+        "lokka",
+        "transport",
+        "http"
+    ],
+    "scripts": {
+        "prepublish": ". ./scripts/prepublish.sh",
+        "lint": "eslint ./lib",
+        "lintfix": "eslint ./lib --fix",
+        "testonly": "mocha $npm_package_options_mocha",
+        "test": "npm run lint && npm run testonly",
+        "build": "babel --plugins transform-runtime lib --ignore __tests__ --out-dir ./dist"
+    },
+    "devDependencies": {
+        "mocha": "2.x.x",
+        "chai": "3.x.x",
+        "eslint": "1.7.x",
+        "babel-eslint": "4.x.x",
+        "eslint-plugin-babel": "2.x.x",
+        "babel-cli": "6.x.x",
+        "babel-core": "6.x.x",
+        "babel-polyfill": "6.x.x",
+        "babel-preset-es2015": "6.x.x",
+        "babel-preset-stage-2": "6.x.x",
+        "babel-plugin-transform-runtime": "6.x.x",
+        "portscanner": "1.x.x",
+        "express": "4.x.x",
+        "express-graphql": "0.4.x",
+        "graphql": "0.4.x",
+        "bluebird": "2.x.x",
+        "lokka": "1.x.x"
+    },
+    "dependencies": {
+        "babel-runtime": "6.x.x",
+        "node-fetch": "^1.5.2",
+        "whatwg-fetch": "^1.0.0"
+    },
+    "peerDependencies": {
+        "lokka": "1.x.x"
+    }
 }


### PR DESCRIPTION
You can now query like 

```

const csrf = { _csrf: 'thisisafaketoken' };
lokka.query(`
  thing {
    a
    b
    c
  }
`, csrf);
```
and it will come out in the body as 

```
request.body = { query: '...', _csrf: '....'}
```

So that koa-csrf can pick it up.

And added a `build` npm script so you dont have to run `scripts/pre-publish.sh` to build